### PR TITLE
replaced deprecated function and check for type before freeing mysql resource

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -25,7 +25,7 @@ $NAMESPACES = "
 // Returns http links for possible URIs found in a text
 // Also adds rel=nofollow attribute to indicate to the search engines that we don't "trust" the link
 function put_links($text) {
-    return ereg_replace("[[:alpha:]]+://[^<>[:space:]]+[[:alnum:]/]","<a href=\"\\0\" rel=\"nofollow\">\\0</a>", $text);
+    return preg_replace('#[[:alpha:]]+://[^<>[:space:]]+[[:alnum:]/]#', '<a href="\0" rel="nofollow">\0</a>', $text);
 }
 
 // verify that an email is valid

--- a/wall.php
+++ b/wall.php
@@ -115,7 +115,7 @@ if (isset($_REQUEST['comment'])) {
     $result = mysql_query($query);
     if (!$result) {
         $ret  .= error('Database error while trying to insert new message!');
-    } else {
+    } else if ($result !== true) {
         mysql_free_result($result);
     }
 
@@ -131,7 +131,7 @@ if (isset($_REQUEST['comment'])) {
         $result = mysql_query($query);
         if (!$result) {
             $ret  .= error('Database error while updating post!');
-        } else {
+        } else if ($result !== true) {
             mysql_free_result($result);
         }
     }
@@ -142,11 +142,11 @@ if (isset($_REQUEST['comment'])) {
     $query .= "name = '" . mysql_real_escape_string($_SESSION['usr']) . "', ";
     $query .= "pic = '" . mysql_real_escape_string($_SESSION['img']) . "' ";
     $query .= "WHERE from_uri = '" . mysql_real_escape_string($_SESSION['webid']) . "'";
-    
+
     $result = mysql_query($query);
     if (!$result) {
         $ret  .= error('Database error while updating user info!');
-    } else {
+    } else if ($result !== true) {
         mysql_free_result($result);
     }
 }

--- a/wall.php
+++ b/wall.php
@@ -74,7 +74,9 @@ if (isset($_REQUEST['del'])) {
             $ok = 1;
             $ok_text = 'The message has been successfully deleted.';
         }
-        mysql_free_result($result);
+        if ($result !== true && $result !== false) {
+            mysql_free_result($result);
+        }
     } else {
         $ok = 0;
         $ok_text = 'The message has NOT been deleted. [unknown cause]';


### PR DESCRIPTION
We have replaced the ereg_replace [1] function (which is deprecated) by preg_replace.
And we have checked if the result of mysql_query is boolean before freeing it.

[1] http://de.php.net/manual/en/function.ereg-replace.php
